### PR TITLE
FPS drop patch

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -76,4 +76,31 @@ configuration_options =
         },
         default = 25
     },
+    {
+        name = "FPS",
+        label = "FPS throttling",
+        hover = "Minimap's throttled updates per second",
+        options =
+        {
+            {description = "Default", data = 0, hover = "Throttling disabled"},
+            {description = "10 fps", data = 0.1},
+            {description = "8 fps", data = 0.125},
+            {description = "6 fps", data = 0.166},
+            {description = "5 fps", data = 0.20},
+            {description = "4 fps", data = 0.25},
+            {description = "3 fps", data = 0.333},
+            {description = "2 fps", data = 0.5},
+            {description = "1 fps", data = 1},
+            {description = "4f/5s", data = 1.25},
+            {description = "2f/3s", data = 1.5},
+            {description = "1f/2s", data = 2},
+            {description = "1f/3s", data = 3},
+            {description = "1f/4s", data = 4},
+            {description = "1f/5s", data = 5},
+            {description = "1f/6s", data = 6},
+            {description = "1f/8s", data = 8},
+            {description = "1f/10s", data = 10},
+        },
+        default = 0
+    },
 }

--- a/modmain.lua
+++ b/modmain.lua
@@ -3,6 +3,7 @@ local mapscale = GetModConfigData("Minimap Size")
 local position_str = GetModConfigData("Position")
 local margin_size_x = GetModConfigData("Horizontal Margin")
 local margin_size_y = GetModConfigData("Vertical Margin")
+local fps = GetModConfigData("FPS")
 
 local dir_vert = 0
 local dir_horiz = 0
@@ -100,6 +101,8 @@ local function AddMiniMap(controls)
 				controls.minimap_small:Show()
 			end
 		end
+
+		controls.minimap_small:SetFPS(fps)
 
 		minimap_small = controls.minimap_small
 

--- a/scripts/widgets/minimapwidget.lua
+++ b/scripts/widgets/minimapwidget.lua
@@ -62,6 +62,9 @@ function MiniMapWidget:SetOpen( state )
     	self.img:Show()
     	self.bg:SetPosition( 0,0,0 )
     	self.bg:SetSize( self.mapsize.w, self.mapsize.h )
+		if not self.minimap:IsVisible() then
+			self.minimap:ToggleVisibility()
+		end
 	else
 		self.open = false
 		local newbuttonpos = Point(0, self.mapsize.h/2 - 20, 0)
@@ -71,6 +74,9 @@ function MiniMapWidget:SetOpen( state )
     	self.img:Hide()
     	self.bg:SetPosition( 0, self.mapsize.h/2 - 20, 0 )
     	self.bg:SetSize( self.mapsize.w, 5 )
+		if self.minimap:IsVisible() then
+			self.minimap:ToggleVisibility()
+		end
 	end
 end
 
@@ -176,7 +182,7 @@ function MiniMapWidget:Offset(dx,dy)
 end
 
 function MiniMapWidget:OnShow()
-	if not self.minimap:IsVisible() then
+	if not self.minimap:IsVisible() and self:IsOpen() then
 		self.minimap:ToggleVisibility()
 	end
 	self.minimap:Zoom(-1000)


### PR DESCRIPTION
Hello.

I've made a patch that aims to help with [FPS drop issue](http://steamcommunity.com/workshop/filedetails/discussion/345692228/610574827760107372/).
It consists of two parts:
1. Disable minimap updating when the minimap is closed.
   This is useful when maximum speed is desired (e.g. during a fight).
2. Minimap FPS throttling
   Minimap updating is enabled only for one frame, then disabled and the next update is scheduled. Delay is configurable.
   This does create uneven experience. During downtime, the game runs smoothly but the minimap is frozen. During update, the game freezes and the minimap updates.

Wording on configuration option might need tweaking, I'm not sure if it's intuitive enough currently.
