### PR TITLE
Fix for crash introduced by latest mod update.

### DIFF
--- a/modmain.lua
+++ b/modmain.lua
@@ -136,7 +136,7 @@ MapWidget_OnZoomIn_base = MapWidget.OnZoomIn
 MapWidget.OnZoomIn = function(self, deltazoom, ...)
 	local returnValues = {MapWidget_OnZoomIn_base( self, deltazoom, ... )}
 	if minimap_small and self.shown then
-		minimap_small.mapscreenzoom = math.max(0,minimap_small.mapscreenzoom + deltazoom)
+		minimap_small.mapscreenzoom = math.max(0,minimap_small.mapscreenzoom + (deltazoom or -0.1))
 	end
 	return unpack(returnValues)
 end
@@ -145,7 +145,7 @@ MapWidget_OnZoomOut_base = MapWidget.OnZoomOut
 MapWidget.OnZoomOut = function(self, deltazoom, ...)
 	local returnValues = {MapWidget_OnZoomOut_base( self, deltazoom, ... )}
 	if minimap_small and self.shown then
-		minimap_small.mapscreenzoom = minimap_small.mapscreenzoom + deltazoom
+		minimap_small.mapscreenzoom = minimap_small.mapscreenzoom + (deltazoom or 0.1)
 	end
 	return unpack(returnValues)
 end


### PR DESCRIPTION
With the latest mod update, the changes to _OnZoomIn_ and _OnZoomOut_ assume that _deltazoom_ is always passed in.
However, Controls's _FocusMapOnWorldPosition_ doesn't pass in any arguments to _OnZoomIn_.
And this will get called whenever someone uses a Message in a Bottle.
When there's no arguments, the game assumes the delta is -0.1 for _OnZoomIn_ and 0.1 for _OnZoomOut_.

This pull request makes it so the mod will use those default values if no delta is provided.